### PR TITLE
[FIX] Format partner name properly when searching from views

### DIFF
--- a/odoo/addons/base/models/res_partner.py
+++ b/odoo/addons/base/models/res_partner.py
@@ -668,6 +668,10 @@ class Partner(models.Model):
                 name = self._get_contact_name(partner, name)
         if self._context.get('show_address_only'):
             name = partner._display_address(without_company=True)
+        if self._context.get('show_email') and partner.email:
+            name = "%s <%s>" % (name, partner.email)
+        if self._context.get('show_vat') and partner.vat:
+            name = "%s ‒ %s" % (name, partner.vat)
         if self._context.get('show_address'):
             name = name + "\n" + partner._display_address(without_company=True)
         name = name.replace('\n\n', '\n')
@@ -675,12 +679,8 @@ class Partner(models.Model):
         if self._context.get('address_inline'):
             splitted_names = name.split("\n")
             name = ", ".join([n for n in splitted_names if n.strip()])
-        if self._context.get('show_email') and partner.email:
-            name = "%s <%s>" % (name, partner.email)
         if self._context.get('html_format'):
             name = name.replace('\n', '<br/>')
-        if self._context.get('show_vat') and partner.vat:
-            name = "%s ‒ %s" % (name, partner.vat)
         return name
 
     def name_get(self):


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
Currently, when searching for a partner with the context variable `{'show_address': True}` combined `{'show_vat': True}` or `{'show_email': True}`, it does not show either VAT or email in the results before clicking on the partner.
This is because it shows only the first line that returns `name_get` function (`_get_name`), and having in the context `{'show_address': True}` formats it with a carriage return just after the customer's name, leaving the VAT and the email at the end.

Since the VAT and email fields are being searched by default in the _name_search function, it is logical and feasible that they are displayed in the first line as if they were search matches.

Current behavior before PR:
Example of how it is now displayed with context `{'show_address': True, 'show_vat': True, 'show_email': True}`:
Azure Interior
4557 De Silva St
Fremont CA 94538
United States <azure.Interior24@example.com> - ESR2537651H

Desired behavior after PR is merged:
Example of how it would be displayed after changes with context `{'show_address': True, 'show_vat': True, 'show_email': True}`:
Customer Azure Interior <azure.Interior24@example.com> - ESR2537651H
4557 De Silva St
Fremont CA 94538
United States

Comments:
In this way, you can see the field you are looking for directly before selecting the record.

This changes are proposed because on Purchase Order, you can view the VAT next to the partner. 
On Sales Order and Account Move (invoice) you can't because `{'show_address': True}` is present on the view field context.

--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr
