### PR TITLE
[OEXP25] stock_picking_batch: Add UoM Category to Auto-Wave options

### DIFF
--- a/addons/stock_picking_batch/models/stock_move_line.py
+++ b/addons/stock_picking_batch/models/stock_move_line.py
@@ -197,6 +197,7 @@ class StockMoveLine(models.Model):
                         or (picking_type.batch_group_by_dest_loc and line.location_dest_id != wave.picking_ids.location_dest_id) \
                         or (picking_type.wave_group_by_product and line.product_id != wave.move_line_ids.product_id) \
                         or (picking_type.wave_group_by_category and line.product_id.categ_id != wave.move_line_ids.product_id.categ_id) \
+                        or (picking_type.wave_group_by_uom_category and line.product_uom_category_id != wave.move_line_ids.product_uom_category_id) \
                         or (picking_type.wave_group_by_location and waves_nearest_parent_locations[wave] != nearest_parent_locations[line].id):
                             continue
 
@@ -256,6 +257,8 @@ class StockMoveLine(models.Model):
                 domain = expression.AND([domain, [('product_id', 'in', lines.product_id.ids)]])
             if picking_type.wave_group_by_category:
                 domain = expression.AND([domain, [('product_id.categ_id', 'in', lines.product_id.categ_id.ids)]])
+            if picking_type.wave_group_by_uom_category:
+                domain = expression.AND([domain, [('product_uom_category_id', 'in', lines.product_uom_category_id.ids)]])
             if picking_type.wave_group_by_location:
                 domain = expression.AND([domain, [('location_id', 'child_of', picking_type.wave_location_ids.ids)]])
 
@@ -284,6 +287,7 @@ class StockMoveLine(models.Model):
                     or (picking_type.batch_group_by_dest_loc and line.location_dest_id != potential_line.location_dest_id) \
                     or (picking_type.wave_group_by_product and line.product_id != potential_line.product_id) \
                     or (picking_type.wave_group_by_category and line.product_id.categ_id != potential_line.product_id.categ_id) \
+                    or (picking_type.wave_group_by_uom_category and line.product_uom_category_id != potential_line.product_uom_category_id) \
                     or (picking_type.wave_group_by_location and lines_nearest_parent_locations[potential_line] != nearest_parent_locations[line].id):
                         continue
 

--- a/addons/stock_picking_batch/models/stock_picking.py
+++ b/addons/stock_picking_batch/models/stock_picking.py
@@ -23,6 +23,7 @@ class StockPickingType(models.Model):
     wave_group_by_category = fields.Boolean('Product Category', help="Split transfers by product category, then group transfers that have the same product category.")
     wave_category_ids = fields.Many2many('product.category', string='Wave Product Categories', help="Categories to consider when grouping waves.")
     wave_group_by_location = fields.Boolean('Location', help="Split transfers by defined locations, then group transfers with the same location.")
+    wave_group_by_uom_category = fields.Boolean('Group by UoM Category', help="Split transfers by UoM Category, then group transfers that have the same UoM Category.")
     wave_location_ids = fields.Many2many('stock.location', string='Wave Locations', help="Locations to consider when grouping waves.", domain="[('usage', '=', 'internal')]")
     batch_max_lines = fields.Integer("Maximum lines",
                                      help="A transfer will not be automatically added to batches that will exceed this number of lines if the transfer is added to it.\n"
@@ -67,7 +68,7 @@ class StockPickingType(models.Model):
 
     @api.model
     def _get_wave_group_by_keys(self):
-        return ['wave_group_by_product', 'wave_group_by_category', 'wave_group_by_location']
+        return ['wave_group_by_product', 'wave_group_by_category', 'wave_group_by_location', 'wave_group_by_uom_category']
 
     @api.model
     def _get_batch_and_wave_group_by_keys(self):

--- a/addons/stock_picking_batch/views/stock_picking_type_views.xml
+++ b/addons/stock_picking_batch/views/stock_picking_type_views.xml
@@ -47,6 +47,11 @@
                                 <field name="wave_category_ids" widget="many2many_tags" placeholder="Select product categories you want to group"
                                     invisible="not wave_group_by_category" required="wave_group_by_category"/>
                             </div>
+                            <span invisible="not auto_batch"/>
+                            <div name="wave_uom_category" class="o_row" invisible="not auto_batch">
+                                <field name="wave_group_by_uom_category"/>
+                                <label for="wave_group_by_uom_category"/>
+                            </div>
                             <span invisible="not auto_batch" groups="stock.group_stock_multi_locations"/>
                             <div name="wave_location" class="o_row" invisible="not auto_batch" groups="stock.group_stock_multi_locations">
                                 <field name="wave_group_by_location"/>


### PR DESCRIPTION
## This code is created to quickly show a possible encapsulation of methods. Do not represent a final version of the code.

# Description of the issue/feature this PR addresses:
Unable to group by UoM Category on Auto-Wave

# Current behavior before PR:
Unable to group by UoM Category on Auto-Wave

# Desired behavior after PR is merged:
Add UoM Category to Auto-Wave Options



MT-11472 @moduon